### PR TITLE
allow msg.satid, msg.tle1 and msg.tle2 to override values in the node

### DIFF
--- a/satellites.js
+++ b/satellites.js
@@ -74,25 +74,27 @@ module.exports = function (RED) {
 
 		this.on('input', function (msg) {
 			var satellites = [];
-        // override tle1 if passed suitable value
-            if  ('satid' in msg)  {
-                if ( (typeof msg.satid === 'string') && (msg.satid.length < 1024) ) {
-                    node.satid = msg.satid
+        
+		// override satid if node value not filled in and passed suitable value
+                if  ( (node.satid == '') && ('satid' in msg) )  {
+                    if ( (typeof msg.satid === 'string') && (msg.satid.length < 1024) ) {
+                        node.satid = msg.satid
+                    }
                 }
-            }
-        // override tle1 if passed suitable value
-            if  ('tle1' in msg)  {
-                if ( (typeof msg.tle1 === 'string') && (msg.tle1.length < 1024) ) {
-                    node.tle1 = msg.tle1
+		// override tle1 if node value not filled in and passed suitable value
+                if  ( (node.tle1 == '') && ('tle1' in msg) )  {
+                    if ( (typeof msg.tle1 === 'string') && (msg.tle1.length < 1024) ) {
+                        node.tle1 = msg.tle1
+                    }
                 }
-            }
-        // override tle1 if passed suitable value
-            if  ('tle2' in msg)  {
-                if ( (typeof msg.tle2 === 'string') && (msg.tle2.length < 1024) ) {
-                    node.tle2 = msg.tle2
+		// override tle2 if node value not filled in and passed suitable value
+                if  ( (node.tle2 == '') && ('tle2' in msg) )  {
+                    if ( (typeof msg.tle2 === 'string') && (msg.tle2.length < 1024) ) {
+                        node.tle2 = msg.tle2
+                    }
                 }
-            }
 
+			
 			// Initialize a satellite record
 			var satrec = satellite.twoline2satrec(node.tle1, node.tle2);
 

--- a/satellites.js
+++ b/satellites.js
@@ -74,6 +74,24 @@ module.exports = function (RED) {
 
 		this.on('input', function (msg) {
 			var satellites = [];
+        // override tle1 if passed suitable value
+            if  ('satid' in msg)  {
+                if ( (typeof msg.satid === 'string') && (msg.satid.length < 1024) ) {
+                    node.satid = msg.satid
+                }
+            }
+        // override tle1 if passed suitable value
+            if  ('tle1' in msg)  {
+                if ( (typeof msg.tle1 === 'string') && (msg.tle1.length < 1024) ) {
+                    node.tle1 = msg.tle1
+                }
+            }
+        // override tle1 if passed suitable value
+            if  ('tle2' in msg)  {
+                if ( (typeof msg.tle2 === 'string') && (msg.tle2.length < 1024) ) {
+                    node.tle2 = msg.tle2
+                }
+            }
 
 			// Initialize a satellite record
 			var satrec = satellite.twoline2satrec(node.tle1, node.tle2);


### PR DESCRIPTION
the code allows for the incoming msg to override the options of the TLE node. This will allow someone to se an http-request node to get the satellite information, pass it (after using a split/join combination) to the TLE node and it will use the values in the incoming msg instead of what is hard coded in the node.